### PR TITLE
Do not convert straight quotes to curly quotes

### DIFF
--- a/escape.js
+++ b/escape.js
@@ -1,5 +1,3 @@
-var smarten = require('smart-quotes')
-
 var special = {
   '&amp;': /&/g,
   '&apos;': /'/g,
@@ -12,6 +10,6 @@ function escape(string) {
     .reduce(
       function(string, escaped) {
         return string.replace(special[escaped], escaped) },
-      smarten(string.replace(/^'s/, '’s'))) }
+      string) }
 
 module.exports = escape

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "dependencies": {
     "commonform-flatten": "^0.7.0",
     "jszip": "^2.4.0",
-    "merge": "^1.2.0",
-    "smart-quotes": "0.0.2"
+    "merge": "^1.2.0"
   },
   "devDependencies": {
     "decimal-numbering": "~1.1.0"


### PR DESCRIPTION
This PR remove the logic that attempts to convert straight quote characters to curly quote characters.

That conversion process is non-trivial. I haven't been able to identify a known-reliable algorithm.
